### PR TITLE
Fix ProcController and ProcRunner shutdown behavior

### DIFF
--- a/appctl/src/appctl_support/proc_controller.py
+++ b/appctl/src/appctl_support/proc_controller.py
@@ -24,8 +24,6 @@ class ProcController(BaseController):
         self.respawn = respawn
         self.start_count = 0
         self.stop_count = 0
-        # Always stop on rospy shutdown.
-        rospy.on_shutdown(self.stop)
 
     def start(self, *args, **kwargs):
         with self.lock:
@@ -52,6 +50,17 @@ class ProcController(BaseController):
                 raise AssertionError('Start/stop count mismatch during stop()')
             self.watcher.shutdown()
             self.watcher = None
+
+    def close(self):
+        try:
+            self.watcher.shutdown()
+        except AttributeError:
+            pass
+        finally:
+            self.spawn_hooks = self.watcher = None
+
+    def __del__(self):
+        self.close()
 
     def add_spawn_hook(self, spawn_hook):
         """

--- a/appctl/src/appctl_support/proc_runner.py
+++ b/appctl/src/appctl_support/proc_runner.py
@@ -42,6 +42,9 @@ class ProcRunner(threading.Thread):
         for spawn_hook in spawn_hooks:
             self.add_spawn_hook(spawn_hook)
 
+    def __del__(self):
+        self.shutdown()
+
     def _kill_proc(self):
         """
         Attempts to kill the process group with SIGTERM.

--- a/appctl/test/appctl_support/test_proc_runner.py
+++ b/appctl/test/appctl_support/test_proc_runner.py
@@ -153,9 +153,9 @@ class TestProcRunnerCleanup(unittest.TestCase):
         gc.collect()
         self.assertIsNone(proc_ref(), 'proc must be freed on shutdown')
 
-        runner.join()
         runner = None
-        self.assertIsNone(runner_ref(), 'runner must be freed post-join')
+        gc.collect()
+        self.assertIsNone(runner_ref(), 'runner must be freed post-delete')
 
 if __name__ == '__main__':
     import rostest


### PR DESCRIPTION
`ProcController` and `ProcRunner` are now garbage collected when dereferenced, guaranteed.